### PR TITLE
(PUP-8943) Match full selmodule name in exists? check

### DIFF
--- a/lib/puppet/provider/selmodule/semodule.rb
+++ b/lib/puppet/provider/selmodule/semodule.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:selmodule).provide(:semodule) do
     debug "Checking for module #{@resource[:name]}"
     execpipe("#{command(:semodule)} --list") do |out|
       out.each_line do |line|
-        if line =~ %r{#{@resource[:name]}\b}
+        if line =~ %r{^#{@resource[:name]}\b}
           return :true
         end
       end

--- a/spec/unit/provider/selmodule_spec.rb
+++ b/spec/unit/provider/selmodule_spec.rb
@@ -27,6 +27,12 @@ describe Puppet::Type.type(:selmodule).provider(:semodule) do
       expect(provider.exists?).to be_nil
     end
 
+    it 'returns nil if module with same suffix is loaded' do
+      allow(provider).to receive(:command).with(:semodule).and_return '/usr/sbin/semodule'
+      allow(provider).to receive(:execpipe).with('/usr/sbin/semodule --list').and_yield StringIO.new("bar\t1.2.3\nmyfoo\t1.0.0\n")
+      expect(provider.exists?).to be_nil
+    end
+
     it 'returns nil if no modules are loaded' do
       allow(provider).to receive(:command).with(:semodule).and_return '/usr/sbin/semodule'
       allow(provider).to receive(:execpipe).with('/usr/sbin/semodule --list').and_yield StringIO.new('')


### PR DESCRIPTION
Add a beginning-of-line marker to the regex to match the
complete selmodule name.

If not matching the beginning of the line, a modulename of
`foo` also matches for a moudlename of `myfoo`.

This is ported from https://github.com/puppetlabs/puppet/pull/6883