### PR TITLE
(MODULES-10945) Core module spring cleaning 2021

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -52,6 +52,7 @@ jobs:
         run: |
           git config --global core.longpaths true
           bundle config set system 'true'
+          bundle config set --local without 'release'
           ${{ matrix.env_set_cmd }}PUPPET_GEM_VERSION=$(ruby -e 'puts /puppet\s+\((.+)\)/.match(`gem list -eld puppet`)[1]')
           bundle update --jobs 4 --retry 3
 

--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -11,10 +11,8 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
-        puppet_version: [ 5, 6, 7 ]
+        puppet_version: [ 6, 7 ]
         include:
-          - puppet_version: 5
-            ruby: 2.4
           - puppet_version: 6
             ruby: 2.5
           - puppet_version: 7

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Run checks
 
     env:
-      ruby_version: 2.5
+      ruby_version: 2.6
       extra_checks: check:symlinks check:git_ignore check:dot_underscore check:test_file
 
     runs-on: 'ubuntu-18.04'

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Prepare testing environment with bundler
         run: |
           git config --global core.longpaths true
+          bundle config set --local without 'release'
           bundle update --jobs 4 --retry 3
 
       - name: Run commits check

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -13,10 +13,8 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
-        puppet_version: [ 5, 6, 7 ]
+        puppet_version: [ 6, 7 ]
         include:
-          - puppet_version: 5
-            ruby: 2.4
           - puppet_version: 6
             ruby: 2.5
           - puppet_version: 7

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -54,6 +54,7 @@ jobs:
         run: |
           git config --global core.longpaths true
           bundle config set system 'true'
+          bundle config set --local without 'release'
           ${{ matrix.env_set_cmd }}PUPPET_GEM_VERSION=$(ruby -e 'puts /puppet\s+\((.+)\)/.match(`gem list -eld puppet`)[1]')
           bundle update --jobs 4 --retry 3
 

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
-        puppet_version: [ 5, 6 ]
+        puppet_version: [ 6, 7 ]
         include:
-          - puppet_version: 5
-            ruby: 2.4
           - puppet_version: 6
             ruby: 2.5
+          - puppet_version: 7
+            ruby: 2.7
 
           - os: 'ubuntu-18.04'
             os_type: 'Linux'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -43,6 +43,7 @@ jobs:
         run: |
           git config --global core.longpaths true
           bundle config set system 'true'
+          bundle config set --local without 'release'
           bundle update --jobs 4 --retry 3
 
       - name: Run unit tests

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,11 @@ group :development do
   gem "github_changelog_generator",                              require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
 end
 
+group :release do
+  gem "puppet-blacksmith", '~> 3.4',                             require: false
+  gem "pdk",                                                     platforms: [:ruby]
+end
+
 puppet_version = ENV['PUPPET_GEM_VERSION']
 facter_version = ENV['FACTER_GEM_VERSION']
 hiera_version = ENV['HIERA_GEM_VERSION']


### PR DESCRIPTION
Create a separate group in the `Gemfile` for `pdk` and `puppet-blacksmith` which are only used for releasing. In the workflow, avoid installing the release group.

Update the workflow that tests with released Puppet gems to also test with Puppet 7.

Bump Ruby version in the static code analysis workflow to 2.6, as 2.5 will be EOL soon.

Remove testing with Puppet 5 from the workflows since it reached EOL.