### PR TITLE
(MODULES-10953) Update metadata.json and pdk version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ end
 
 group :release do
   gem "puppet-blacksmith", '~> 3.4',                             require: false
-  gem "pdk",                                                     platforms: [:ruby]
+  gem "pdk", '~> 2.0',                                           platforms: [:ruby]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/metadata.json
+++ b/metadata.json
@@ -12,78 +12,43 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "CentOS"
     },
     {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "OracleLinux"
     },
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "RedHat"
     },
     {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "Scientific"
     },
     {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "8"
-      ]
+      "operatingsystem": "Debian"
     },
     {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04"
-      ]
+      "operatingsystem": "Ubuntu"
     },
     {
-      "operatingsystem": "windows",
-      "operatingsystemrelease": [
-        "2008 R2",
-        "2012 R2",
-        "10"
-      ]
+      "operatingsystem": "windows"
     },
     {
-      "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "25"
-      ]
+      "operatingsystem": "Fedora"
     },
     {
-      "operatingsystem": "Darwin",
-      "operatingsystemrelease": [
-        "16"
-      ]
+      "operatingsystem": "Darwin"
     },
     {
-      "operatingsystem": "SLES",
-      "operatingsystemrelease": [
-        "12"
-      ]
+      "operatingsystem": "SLES"
     },
     {
-      "operatingsystem": "Solaris",
-      "operatingsystemrelease": [
-        "11"
-      ]
+      "operatingsystem": "Solaris"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.14.0",


### PR DESCRIPTION
To avoid having to update this everytime we release a new agent
platform, it should be enough to specify the supported OS, without
specific versions. It is assumed that for each OS in metadata.json, the
versions supported are the same as what the agent itself supports.