### PR TITLE
(MODULES-11183) remove Windows from metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,9 +30,6 @@
       "operatingsystem": "Ubuntu"
     },
     {
-      "operatingsystem": "windows"
-    },
-    {
       "operatingsystem": "Fedora"
     },
     {


### PR DESCRIPTION
SELinux cannot work on Windows, remove Windows from supported
operating systems listed in metadata