### PR TITLE
(maint) Updates macOS GitHub Actions runners

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -10,7 +10,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-20.04', 'macos-10.15', 'windows-2019' ]
+        os: [ 'ubuntu-20.04', 'macos-11', 'windows-2019' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -22,7 +22,7 @@ jobs:
             os_type: 'Linux'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest.gem'
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-20.04', 'macos-10.15', 'windows-2019' ]
+        os: [ 'ubuntu-20.04', 'macos-11', 'windows-2019' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -24,7 +24,7 @@ jobs:
             os_type: 'Linux'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest.gem'
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-20.04', 'macos-10.15', 'windows-2019' ]
+        os: [ 'ubuntu-20.04', 'macos-11', 'windows-2019' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -22,7 +22,7 @@ jobs:
 
           - os: 'ubuntu-20.04'
             os_type: 'Linux'
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             os_type: 'macOS'
           - os: 'windows-2019'
             os_type: 'Windows'


### PR DESCRIPTION
GitHub deprecated macOS 10.15 (Catalina) runners for GitHub Actions in December 2022. This commit updates those runners to macOS 11 (Big Sur).