### PR TITLE
(PA-5804) Update Checkout GitHub Action

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -28,7 +28,7 @@ jobs:
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
     - name: "Checkout Source"
       if: ${{ github.repository_owner == 'puppetlabs' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           clean: true
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           clean: true

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: 'ubuntu-20.04'
     steps:
       - name: Checkout current PR code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/rakelib/commits.rake
+++ b/rakelib/commits.rake
@@ -1,4 +1,4 @@
-desc "verify that commit messages match CONTRIBUTING.md requirements"
+desc "verify that commit summaries are properly formatted"
 task(:commits) do
   # This rake task looks at the summary from every commit from this branch not
   # in the branch targeted for a PR.
@@ -7,11 +7,10 @@ task(:commits) do
   %x{git log --no-merges --pretty=%s #{commit_range}}.each_line do |commit_summary|
     # This regex tests for the currently supported commit summary tokens.
     # The exception tries to explain it in more full.
-    if /^Release prep|\((maint|packaging|doc|docs|modules-\d+)\)|revert/i.match(commit_summary).nil?
-      raise "\n\n\n\tThis commit summary didn't match CONTRIBUTING.md guidelines:\n" \
-        "\n\t\t#{commit_summary}\n" \
-        "\tThe commit summary (i.e. the first line of the commit message) should start with one of:\n"  \
-        "\t\t(MODULES-<digits>) # this is most common and should be a ticket at tickets.puppet.com\n" \
+    if /^Release prep|\((maint|packaging|doc|docs|modules|pa-\d+)\)|revert/i.match(commit_summary).nil?
+      raise "\n\n\n\tPlease make sure that your commit summary (i.e. the first line of the commit message) starts with one of the following:\n"  \
+        "\t\t(PA-<digits>)\n" \
+        "\t\t(MODULES-<digits>)\n" \
         "\t\t(docs)\n" \
         "\t\t(docs)(DOCUMENT-<digits>)\n" \
         "\t\t(packaging)\n"


### PR DESCRIPTION
This PR updates the Checkout Action used in GitHub Actions from v3 to v4 to deal with a NodeJS EOL, and updates the commit Rake task to use an active Jira project (PA) and no longer reference a non-existent CONTRIBUTING.md