### PR TITLE
Remove Vox acceptance gem

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,11 +2,6 @@
   default_configs:
     Lint/Void:
       Enabled: false
-Gemfile:
-  optional:
-    ":system_tests":
-      - gem: voxpupuli-acceptance
-
 appveyor.yml:
   delete: true
 .travis.yml:

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,6 @@ end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]
   gem "serverspec", '~> 2.41',   require: false
-  gem "voxpupuli-acceptance",    require: false
 end
 group :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,6 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'github_changelog_generator/task' if Gem.loaded_specs.key? 'github_changelog_generator'
 require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
-require 'voxpupuli/acceptance/rake'
 
 def changelog_user
   return unless Rake.application.top_level_tasks.include? "changelog"


### PR DESCRIPTION
We do not currently run Beaker acceptance tests against this module. This commit removes the voxpupuli-acceptance gem, which provides the Beaker Rake task, from .sync.yml, the Gemfile, and the Rakefile.